### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ $ vagrant ssh
 ```
 $ cd /vagrant
 $ bin/bundle install
+$ bin/rbenv rehash
 $ bin/rake db:migrate
 $ bin/rails s -b 0.0.0.0
 ```


### PR DESCRIPTION
"rbenv rehash" to make sure the executables from the gems we just installed (like rails) are available. Without this command, terminal will tell us 'rails' not installed